### PR TITLE
Fix broken link to zippable banana image

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,7 +367,7 @@ em[oji]{
           <ul>
             <li><a href="https://github.com/bdon/eyeball_pong"><b>Eyeball Pong</b></a>
               <br>Pong game you play by not looking at it.</li>
-            <li><a href="https://bostonstupidhackathon.com/zippable-banana.jpg"><b>Zippable Banana</b></a>
+            <li><a href="https://bostonstupidhackathon.com/2017/zippable-banana.jpg"><b>Zippable Banana</b></a>
               <br>A banana peel that you can zip back up later.</li>
             <li><a href="https://www.youtube.com/watch?v=BRtc7A2eizc"><b>Beer Selfie Stick</b></a>
               <br>A selfie stick that lets you pour beer in your mouth before you take a photo.</li>


### PR DESCRIPTION
The zippable banana link featured on the site is now broken: https://bostonstupidhackathon.com/zippable-banana.jpg

Updated to the correct one: https://bostonstupidhackathon.com/2017/zippable-banana.jpg